### PR TITLE
remove reek rules marked as redundant with rubocop

### DIFF
--- a/ruby/reek/default.yml
+++ b/ruby/reek/default.yml
@@ -79,26 +79,10 @@ detectors:
   SubclassedFromCoreClass:
     enabled: true
     exclude: []
-  # Already catch by rubocop.
-  TooManyConstants:
-    enabled: false
-    exclude: []
-    max_constants: 5
   TooManyInstanceVariables:
     enabled: false
     exclude: []
     max_instance_variables: 4
-  # Already catch by rubocop.
-  TooManyMethods:
-    enabled: false
-    exclude: []
-    max_methods: 15
-  # Already catch by rubocop.
-  TooManyStatements:
-    enabled: false
-    exclude:
-    - initialize
-    max_statements: 5
   UncommunicativeMethodName:
     enabled: true
     exclude: []
@@ -135,10 +119,6 @@ detectors:
     - "/^_$/"
     - "/V[0-9]beta[0-9]$/"
     - "/V[0-9]alpha[0-9]$/"
-  # Already catch by rubocop.
-  UnusedParameters:
-    enabled: false
-    exclude: []
   UnusedPrivateMethod:
     enabled: false
     exclude: []


### PR DESCRIPTION
Are they actually redundant or just marked as redudant? @papa-cool 