### PR TITLE
Disable feature envy and unused private

### DIFF
--- a/ruby/reek/default.yml
+++ b/ruby/reek/default.yml
@@ -30,7 +30,7 @@ detectors:
     max_calls: 1
     allow_calls: []
   FeatureEnvy:
-    enabled: true
+    enabled: false
     exclude: []
   InstanceVariableAssumption:
     enabled: false
@@ -140,7 +140,7 @@ detectors:
     enabled: false
     exclude: []
   UnusedPrivateMethod:
-    enabled: false
+    enabled: true
     exclude: []
   UtilityFunction:
     enabled: true


### PR DESCRIPTION
disable feature envy and unused private method

- disable UnusedPrivateMethod because of known limitations, see https://github.com/troessner/reek/blob/v5.0.2/docs/Unused-Private-Method.md
- disable FeatureEnvy because of seen isues, see  jobteaser/jobteaser#11630 (comment)