### PR TITLE
feat(reek): remove check on rails migration

### DIFF
--- a/ruby/reek/default.yml
+++ b/ruby/reek/default.yml
@@ -146,3 +146,6 @@ detectors:
     enabled: true
     exclude: []
     public_methods_only: false
+
+exclude_paths:
+  - db/migrate


### PR DESCRIPTION
Architecture of rails migration are always the same.
Furthermore, it does not depend on us.
That is why we do not need smell check here.