### PR TITLE
feat(rubocop): allow prefix _ for memoization

### DIFF
--- a/ruby/rubocop/default.yml
+++ b/ruby/rubocop/default.yml
@@ -82,6 +82,11 @@ Metrics/BlockLength:
     - config/routes.rb
     - config/initializers/secure_headers.rb
 
+# ===================================== Department Naming ==========================================
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
 # ===================================== Department Style ===========================================
 
 Style/Alias:


### PR DESCRIPTION
When using underscore as prefix for memoization,
it indicate the variable must not be used outside the method.

It is commonly used on the jt codebase with 345 occurrences.