### PR TITLE
update configuration

### DIFF
--- a/ruby/rubocop/default.yml
+++ b/ruby/rubocop/default.yml
@@ -11,7 +11,7 @@ Bundler/OrderedGems:
 
 # ===================================== Department Layout ==========================================
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/DotPosition:


### PR DESCRIPTION
```
❯ bundle exec rubocop --version
0.80.1
❯ bundle exec rubocop
.rubocop-https---raw-githubusercontent-com-jobteaser-shared-config-files-master-ruby-rubocop-default-yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: The `Layout/AlignParameters` cop has been renamed to `Layout/ParameterAlignment`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-jobteaser-shared-config-files-master-ruby-rubocop-default-yml, please update it)
```