### PR TITLE
Update config rubocop

### DIFF
--- a/ruby/rubocop/default.yml
+++ b/ruby/rubocop/default.yml
@@ -54,6 +54,11 @@ Layout/MultilineOperationIndentation:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Layout/LineLength:
+  Max: 100 # Default is 80
+  Exclude:
+    - config/schedule.rb
+
 # ==================================== Department Metrics ==========================================
 
 Metrics/AbcSize:
@@ -61,11 +66,6 @@ Metrics/AbcSize:
 
 Metrics/ClassLength:
   Max: 100 # Default is 100
-
-Metrics/LineLength:
-  Max: 100 # Default is 80
-  Exclude:
-    - config/schedule.rb
 
 Metrics/MethodLength:
   Max: 10 # Default is 10

--- a/ruby/rubocop/default.yml
+++ b/ruby/rubocop/default.yml
@@ -3,6 +3,7 @@
 
 AllCops:
   TargetRubyVersion: 2.5
+  NewCops: enable
 
 # ==================================== Department Bundler ==========================================
 


### PR DESCRIPTION
I use Virtual Code with an extension Rubocop. I have two messages when I save a ruby file.

The first:
```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

Please also note that can also opt-in to new cops by default by adding this to your config:
AllCops:
     NewCops: enable
```

The second:
```
Metrics/LineLength has the wrong namespace - should be Layout
```

I have created this PR to fix these two warning.